### PR TITLE
Add complete support for cross compiling from linux for windows

### DIFF
--- a/blocks/boost/install/build_jobs.cmake
+++ b/blocks/boost/install/build_jobs.cmake
@@ -97,10 +97,15 @@ function(BII_BOOST_BUILD_LIBS_PARALLEL LIBS B2_CALL VERBOSE BOOST_DIR)
 	foreach(lib ${LIBS})
 		message("Starting ${lib} library build job...")
 
-		execute(${B2_CALL} --with-${lib} WORKING_DIRECTORY ${BOOST_DIR}
-			    --success-callback __execute_success_handler
-			    --error-callback __job_error_handler
-			    --async)
+		if(CMAKE_CROSSCOMPILING)
+			# workaround: `execute' calls PowerShell when cross compiling from linux for windows
+			execute_process(COMMAND ${B2_CALL} --with-${lib} WORKING_DIRECTORY ${BOOST_DIR})
+		else()
+			execute(${B2_CALL} --with-${lib} WORKING_DIRECTORY ${BOOST_DIR}
+					  --success-callback __execute_success_handler
+					  --error-callback __job_error_handler
+					  --async)
+		endif()
 
 		ans(handle)
 		set(handles_list ${handles_list} ${handle})

--- a/blocks/boost/install/install.cmake
+++ b/blocks/boost/install/install.cmake
@@ -201,7 +201,20 @@ function(__BII_BOOST_INSTALL)
 
         set(__BII_BOOST_B2_CALL ${__BII_BOOST_B2_CALL} cxxflags="-stdlib=libc++" linkflags="-stdlib=libc++" ${SCOPE})
     endif()
-    
+
+    if(CMAKE_CROSSCOMPILING)
+      BII_BOOST_COMPUTE_TOOLSET_NAME(BII_BOOST_TOOLSET_NAME)
+      file(WRITE ${BII_BOOST_DIR}/user-config.jam "using ${BII_BOOST_TOOLSET_NAME} : : ${CMAKE_CXX_COMPILER} : <rc>${CMAKE_RC_COMPILER} <archiver>${CMAKE_AR} <ranlib>${CMAKE_RANLIB} ;")
+
+      set(__BII_BOOST_B2_CALL ${__BII_BOOST_B2_CALL} --user-config=${BII_BOOST_DIR}/user-config.jam ${SCOPE})
+
+      if (WIN32)
+        set(__BII_BOOST_B2_CALL ${__BII_BOOST_B2_CALL} target-os=windows threadapi=win32 ${SCOPE})
+      else()
+        message(FATAL_ERROR "Target not supported for cross compiling. Stopping Boost installation")
+      endif()
+    endif()
+
     #Boost
 
     #FindBoost directories

--- a/blocks/boost/install/utils.cmake
+++ b/blocks/boost/install/utils.cmake
@@ -44,7 +44,7 @@ function(COMPILER_VERSION _ret)
   set(${_ret} ${__version} PARENT_SCOPE)
 endfunction()
 
-function(BII_BOOST_COMPUTE_TOOLSET _ret)
+function(BII_BOOST_COMPUTE_TOOLSET_NAME _ret)
 	if(CMAKE_CXX_COMPILER_ID STREQUAL "Intel"
       OR CMAKE_CXX_COMPILER MATCHES "icl"
       OR CMAKE_CXX_COMPILER MATCHES "icpc")
@@ -60,7 +60,11 @@ function(BII_BOOST_COMPUTE_TOOLSET _ret)
 	else()
 		message(FATAL_ERROR "Unknown compiler, unable to compute toolset")
 	endif()
+	set(${_ret} ${__toolset_name} PARENT_SCOPE)
+endfunction()
 
+function(BII_BOOST_COMPUTE_TOOLSET _ret)
+	BII_BOOST_COMPUTE_TOOLSET_NAME(__toolset_name)
 	COMPILER_VERSION(__version)
 
     if(__version AND (NOT (CMAKE_SYSTEM_NAME MATCHES "Darwin")))


### PR DESCRIPTION
Complete #15 

Tested (examples/boost-filesystem, examples/boost-flyweight, examples/boost-multiindex, examples/boost-phoenix, examples/boost-signals) on Ubuntu 14.04.2 with 

```
bii configure \
  -DCMAKE_TOOLCHAIN_FILE=~/Toolchain-cross-mingw.cmake \
  -DCOMPILER_PREFIX=i686-w64-mingw32
bii build
```

~/Toolchain-cross-mingw.cmake:

```
set(CMAKE_SYSTEM_NAME Windows)
set(CMAKE_RC_COMPILER ${COMPILER_PREFIX}-windres)
set(CMAKE_C_COMPILER ${COMPILER_PREFIX}-gcc)
set(CMAKE_CXX_COMPILER ${COMPILER_PREFIX}-g++)
set(CMAKE_FIND_ROOT_PATH  /usr/${COMPILER_PREFIX} )
set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
```

Boost Context do not compile, because it needs a windows assembler: http://blog.biicode.com/dependency-management-boost-libraries/
